### PR TITLE
Fix Mixer recipe configuration

### DIFF
--- a/src/main/java/ipsis/dyetopia/manager/MixerManager.java
+++ b/src/main/java/ipsis/dyetopia/manager/MixerManager.java
@@ -55,7 +55,7 @@ public class MixerManager {
         }
 
         public int getPureAmount() {
-            return this.white.amount;
+            return this.pure.amount;
         }
 
         public FluidStack getRedFluidStack() {


### PR DESCRIPTION
Interestingly, because the mistake is not duplicated in getPureFluidStack(), changing the white config value makes the mixer stop working entirely because TileEntityMixer.isOutputValid() will always return false.
